### PR TITLE
Updated gitignore with maven release files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,10 @@
 *.iws
 *.iml
 
+## Maven release files 
+pom.xml.releaseBackup
+release.properties
+
 target/
 
 work/


### PR DESCRIPTION
I added these backed up files that the maven release plugin creates if a release fails.  It ensures that the files are not accidentally checked in.
